### PR TITLE
fix: grant write permissions to github actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This commit adds the `permissions` block with `contents: write` to the `deploy.yml` workflow file.

This is necessary to allow the `peaceiris/actions-gh-pages` action to push the built site to the `gh-pages` branch. This resolves the "Permission denied" error during deployment.